### PR TITLE
Make battles deterministic

### DIFF
--- a/src/_testing/utils.ts
+++ b/src/_testing/utils.ts
@@ -1,10 +1,14 @@
 import { PieceModel } from "@common/models";
 import { createTileCoordinates } from "@common/models/position";
+import { DefinitionProvider } from "@common/game/definitionProvider";
+
+const definitionProvider = new DefinitionProvider();
 
 export const createMockPiece = (id: string): PieceModel => ({
   id,
   ownerId: "123",
   definitionId: 1,
+  definition: definitionProvider.get(1),
   stage: 0,
   position: createTileCoordinates(0, 0),
   facingAway: true,

--- a/src/app/store/sagas/index.ts
+++ b/src/app/store/sagas/index.ts
@@ -4,7 +4,6 @@ import { gamePhase } from "./actions/gamePhase";
 import { preventAccidentalClose } from "./actions/preventAccidentalClose";
 import { battle } from "@common/match/combat/battleSaga";
 import { TurnSimulator } from "@common/match/combat/turnSimulator";
-import { DefinitionProvider } from "@common/game/definitionProvider";
 import { DEFAULT_TURN_COUNT, DEFAULT_TURN_DURATION } from "@common/models/constants";
 import { AppState } from "../state";
 import { announcement } from "./actions/announcement";
@@ -35,7 +34,7 @@ export const rootSaga = function*() {
                     yield fork(cardShopSagaFactory<AppState>(playerId)),
                     yield fork(
                         battle,
-                        new TurnSimulator(new DefinitionProvider()),
+                        new TurnSimulator(),
                         DEFAULT_TURN_COUNT,
                         DEFAULT_TURN_DURATION
                     )

--- a/src/benchmark/battle.ts
+++ b/src/benchmark/battle.ts
@@ -6,27 +6,34 @@ import { TurnSimulator } from "@common/match/combat/turnSimulator";
 import { DefinitionProvider } from "@common/game/definitionProvider";
 import { DEFAULT_TURN_COUNT } from "@common/models/constants";
 import { EventChannel } from "redux-saga";
-import { BoardState } from "@common/board";
+import { BoardState, boardReducer } from "@common/board";
+import { createPiece } from "@common/utils/piece-utils";
+import { addBoardPiece } from "@common/board/actions/boardActions";
 
 const definitionProvider = new DefinitionProvider();
-const simulator = new TurnSimulator(definitionProvider);
+const simulator = new TurnSimulator();
 
-const pieces: BoardState = {
+let board: BoardState = {
   pieces: {},
   piecePositions: {},
   locked: true
 };
+
 // todo these need tying into GRID_SIZE
-// [
-//   createPiece(definitionProvider, "bot-a", 1, [2, 2], null),
-//   createPiece(definitionProvider, "bot-a", 1, [3, 3], null),
-//   createPiece(definitionProvider, "bot-a", 1, [4, 3], null),
-//   createPiece(definitionProvider, "bot-a", 1, [5, 2], null),
-//   createPiece(definitionProvider, "bot-b", 1, [2, 5], null),
-//   createPiece(definitionProvider, "bot-b", 1, [3, 4], null),
-//   createPiece(definitionProvider, "bot-b", 1, [4, 4], null),
-//   createPiece(definitionProvider, "bot-b", 1, [4, 4], null)
-// ];
+const pieces = [
+  createPiece(definitionProvider, "bot-a", 1, [0, 0], null),
+  createPiece(definitionProvider, "bot-a", 1, [1, 0], null),
+  createPiece(definitionProvider, "bot-a", 1, [2, 1], null),
+  createPiece(definitionProvider, "bot-a", 1, [3, 1], null),
+  createPiece(definitionProvider, "bot-b", 1, [4, 4], null),
+  createPiece(definitionProvider, "bot-b", 1, [5, 4], null),
+  createPiece(definitionProvider, "bot-b", 1, [5, 5], null),
+  createPiece(definitionProvider, "bot-b", 1, [6, 5], null)
+];
+
+pieces.forEach(piece => {
+  board = boardReducer(board, addBoardPiece(piece, piece.position.x, piece.position.y));
+});
 
 const listenForBattleFinish = (channel: EventChannel<BattleAction>, resolve: (value: number) => void) => {
   channel.take(action => {
@@ -50,7 +57,7 @@ const run = async () => {
   for (let i = 0; i < TARGET_ITERATIONS; i++) {
     const iterationStartMs = present();
 
-    const channel = battleEventChannel(simulator, 0, pieces, DEFAULT_TURN_COUNT, 100);
+    const channel = battleEventChannel(simulator, 0, board, DEFAULT_TURN_COUNT, 100);
     const turnsTaken = await waitForBattleFinish(channel);
 
     const iterationMsTaken = present() - iterationStartMs;

--- a/src/shared/game/game.ts
+++ b/src/shared/game/game.ts
@@ -72,7 +72,7 @@ export class Game {
         this.lastLivingPlayerCount = livingPlayers.length;
 
         this.deck = new CardDeck(this.definitionProvider.getAll());
-        this.turnSimulator = new TurnSimulator(this.definitionProvider);
+        this.turnSimulator = new TurnSimulator();
 
         this.playerList.onUpdate(playerList => this.players.forEach(p => p.onPlayerListUpdate(playerList)));
 

--- a/src/shared/match/combat/movement.ts
+++ b/src/shared/match/combat/movement.ts
@@ -34,7 +34,7 @@ const getAttackingTiles = (facingUp: boolean, attackType: AttackType) => {
 const getLivingEnemies = (piece: PieceModel, board: BoardState): PieceModel[] => {
     const output: PieceModel[] = [];
 
-    for (const [ id, other ] of Object.entries(board.pieces)) {
+    for (const [id, other] of Object.entries(board.pieces)) {
         if (other.ownerId !== piece.ownerId && other.currentHealth > 0) {
             output.push(other);
         }
@@ -116,7 +116,29 @@ const findClosestEnemy = (piece: PieceModel, board: BoardState) => {
     }));
 
     // sort by column then by row
-    enemyDeltas.sort((a, b) => a.delta.y - b.delta.y || a.delta.x - b.delta.x);
+    enemyDeltas.sort((a, b) => {
+        if (a.delta.y < b.delta.y) {
+            return -1;
+        }
+
+        if (a.delta.y > b.delta.y) {
+            return 1;
+        }
+
+        if (a.delta.x < b.delta.x) {
+            return -1;
+        }
+
+        if (a.delta.x > b.delta.x) {
+            return 1;
+        }
+
+        if (a.enemy.definition.cost > b.enemy.definition.cost) {
+            return -1;
+        }
+
+        return 1;
+    });
 
     return enemyDeltas[0].enemy;
 };

--- a/src/shared/match/combat/movement.ts
+++ b/src/shared/match/combat/movement.ts
@@ -72,7 +72,7 @@ const getTargetPiece = (piece: PieceModel, board: BoardState) => {
     return target;
 };
 
-export const getAttackableEnemy = (piece: PieceModel, attackType: AttackType, board: BoardState) => {
+export const getAttackableEnemyFromCurrentPosition = (piece: PieceModel, attackType: AttackType, board: BoardState) => {
     const target = getTargetPiece(piece, board);
 
     if (target && canAttack(piece, target, attackType)) {
@@ -84,7 +84,7 @@ export const getAttackableEnemy = (piece: PieceModel, attackType: AttackType, bo
     for (const direction of attackDirections) {
         const targetPosition = applyVector(piece.position, direction);
 
-        // targetPosition will be null if there direction is out of bounds
+        // targetPosition will be null if the direction is out of bounds
         if (targetPosition === null) {
             continue;
         }

--- a/src/shared/match/combat/turnSimulator.ts
+++ b/src/shared/match/combat/turnSimulator.ts
@@ -1,18 +1,10 @@
 import { PieceModel } from "../../models";
-import { CreatureStats } from "../../models/creatureDefinition";
 import { getAttackableEnemy, getNewPiecePosition } from "./movement";
 import { getRelativeDirection } from "../../models/position";
 import { getTypeAttackBonus } from "@common/utils";
-import { DefinitionProvider } from "../../game/definitionProvider";
-import { CreatureType } from "../../models/creatureType";
 import { BoardState, boardReducer } from "@common/board";
 import { updateBoardPiece, updateBoardPieces, removeBoardPiece } from "@common/board/actions/boardActions";
-
-interface PieceCombatInfo {
-    piece: PieceModel;
-    stats: CreatureStats;
-    type: CreatureType;
-}
+import { getStats } from "@common/utils/piece-utils";
 
 const DYING_DURATION = 10;
 const ATTACK_TURN_DURATION = 2;
@@ -22,12 +14,6 @@ const MOVE_TURN_DURATION = 2;
 const getCooldownForSpeed = (speed: number) => (180 - speed) / 24;
 
 export class TurnSimulator {
-    private definitionProvider: DefinitionProvider;
-
-    constructor(definitionProvider: DefinitionProvider) {
-        this.definitionProvider = definitionProvider;
-    }
-
     public simulateTurn(currentTurn: number, board: BoardState) {
         const pieceIds = Object.keys(board.pieces);
 
@@ -46,6 +32,8 @@ export class TurnSimulator {
             hit: null,
         };
 
+        const attackerStats = getStats(attacker);
+
         if (attacker.battleBrain.removeFromBoardAtTurn === currentTurn) {
             return boardReducer(board, removeBoardPiece(pieceId));
         }
@@ -58,9 +46,8 @@ export class TurnSimulator {
             attacker.battleBrain.removeFromBoardAtTurn = currentTurn + DYING_DURATION;
             return boardReducer(board, updateBoardPiece(attacker));
         }
-
-        const attackerCombatInfo = this.getPieceCombatInfo(attacker);
-        const cooldown = getCooldownForSpeed(attackerCombatInfo.stats.speed);
+;
+        const cooldown = getCooldownForSpeed(attackerStats.speed);
 
         if (attacker.battleBrain.canMoveAtTurn === null) {
             attacker.battleBrain.canMoveAtTurn = currentTurn + cooldown;
@@ -71,7 +58,7 @@ export class TurnSimulator {
         }
 
         // try to find an enemy in attack range
-        const attackableEnemy = getAttackableEnemy(attacker, attackerCombatInfo.stats.attackType, board);
+        const attackableEnemy = getAttackableEnemy(attacker, attackerStats.attackType, board);
         if (attackableEnemy) {
             // if there's an enemy in range but we can't attack it yet, just wait for cooldown
             if (attacker.battleBrain.canAttackAtTurn > currentTurn) {
@@ -84,14 +71,18 @@ export class TurnSimulator {
                 return boardReducer(board, updateBoardPiece(attacker));
             }
 
-            const defenderCombatInfo = this.getPieceCombatInfo(attackableEnemy);
+            const attackResult = this.attack(attacker, attackableEnemy);
 
-            const updatedFighters = this.attack(attackerCombatInfo, defenderCombatInfo);
-            updatedFighters.attacker.targetPieceId = updatedFighters.defender.id;
+            // if no attack result, no need to update defender
+            if (attackResult == null) {
+                return boardReducer(board, updateBoardPiece(attacker));
+            }
 
-            attacker.battleBrain.canAttackAtTurn = currentTurn + ATTACK_TURN_DURATION + getCooldownForSpeed(attackerCombatInfo.stats.speed);
+            attackResult.attacker.targetPieceId = attackResult.defender.id;
 
-            return boardReducer(board, updateBoardPieces([updatedFighters.attacker, updatedFighters.defender]));
+            attacker.battleBrain.canAttackAtTurn = currentTurn + ATTACK_TURN_DURATION + getCooldownForSpeed(attackerStats.speed);
+
+            return boardReducer(board, updateBoardPieces([attackResult.attacker, attackResult.defender]));
         }
 
         // clear target if they're no longer in attack range
@@ -109,50 +100,40 @@ export class TurnSimulator {
 
         attacker.position = newPosition;
 
-        attacker.battleBrain.canMoveAtTurn = currentTurn + MOVE_TURN_DURATION + getCooldownForSpeed(attackerCombatInfo.stats.speed);
+        attacker.battleBrain.canMoveAtTurn = currentTurn + MOVE_TURN_DURATION + getCooldownForSpeed(attackerStats.speed);
         attacker.battleBrain.canBeAttackedAtTurn = currentTurn + MOVE_TURN_DURATION + 2;
         attacker.battleBrain.canAttackAtTurn = currentTurn + MOVE_TURN_DURATION + 2;
 
         return boardReducer(board, updateBoardPiece(attacker));
     }
 
-    private getPieceCombatInfo(piece: PieceModel) {
-        const definition = this.definitionProvider.get(piece.definitionId);
-
-        return {
-            piece,
-            stats: definition.stages[piece.stage],
-            type: definition.type
-        };
-    }
-
-    private attack(attacker: PieceCombatInfo, defender: PieceCombatInfo) {
-        if (attacker.piece.currentHealth === 0) {
-            return {
-                attacker: attacker.piece,
-                defender: defender.piece
-            };
+    private attack(attacker: PieceModel, defender: PieceModel) {
+        if (attacker.currentHealth === 0) {
+            return null;
         }
 
-        const attackBonus = getTypeAttackBonus(attacker.type, defender.type);
-        const damage = (attacker.stats.attack / defender.stats.defense) * attackBonus * 8; // todo tweak this
-        const newDefenderHealth = Math.max(defender.piece.currentHealth - damage, 0);
+        const attackerStats = getStats(attacker);
+        const defenderStats = getStats(defender);
+
+        const attackBonus = getTypeAttackBonus(attacker.definition.type, defender.definition.type);
+        const damage = (attackerStats.attack / defenderStats.defense) * attackBonus * 8; // todo tweak this
+        const newDefenderHealth = Math.max(defender.currentHealth - damage, 0);
 
         return {
             attacker: {
-                ...attacker.piece,
+                ...attacker,
                 attacking: {
-                    attackType: attacker.stats.attackType,
-                    direction: getRelativeDirection(attacker.piece.position, defender.piece.position),
+                    attackType: attackerStats.attackType,
+                    direction: getRelativeDirection(attacker.position, defender.position),
                     damage
                 },
-                targetPieceId: defender.piece.id
+                targetPieceId: defender.id
             },
             defender: {
-                ...defender.piece,
+                ...defender,
                 currentHealth: newDefenderHealth,
                 hit: {
-                    direction: getRelativeDirection(defender.piece.position, attacker.piece.position),
+                    direction: getRelativeDirection(defender.position, attacker.position),
                     damage
                 }
             }

--- a/src/shared/models/piece.ts
+++ b/src/shared/models/piece.ts
@@ -1,5 +1,5 @@
 import { TileCoordinates } from "./position";
-import { AttackType } from "./creatureDefinition";
+import { AttackType, CreatureDefinition } from "./creatureDefinition";
 
 export interface AttackDetails {
     direction: TileCoordinates;
@@ -19,7 +19,10 @@ export interface MovementDetails {
 export interface PieceModel {
     id: string;
     ownerId: string;
+
     definitionId: number;
+    definition: CreatureDefinition;
+
     stage: number;
     position: TileCoordinates;
 

--- a/src/shared/utils/piece-utils.ts
+++ b/src/shared/utils/piece-utils.ts
@@ -17,6 +17,7 @@ export const createPiece = (
         id: id || uuid(),
         ownerId,
         definitionId,
+        definition: definitionProvider.get(definitionId),
         position: createTileCoordinates(...position),
         facingAway: true,
         maxHealth: stats.hp,
@@ -25,6 +26,8 @@ export const createPiece = (
         targetPieceId: null
     };
 };
+
+export const getStats = (piece: PieceModel) => piece.definition.stages[piece.stage];
 
 export const createPieceFromCard = (
     definitionProvider: DefinitionProvider,


### PR DESCRIPTION
Fix #245 

- Sort pieces by speed before taking turn
- Target enemies with higher cost if there's a tie break