### PR TITLE
Fixed bug where spacer not added to overlay screen

### DIFF
--- a/packages/app/src/game/module/board/overlays/readyOverlay.tsx
+++ b/packages/app/src/game/module/board/overlays/readyOverlay.tsx
@@ -28,10 +28,9 @@ const ReadyOverlay: React.FunctionComponent = () => {
 	if (!opponent || !inReadyPhase || spectatingPlayer) {
 		return null;
 	}
-	const renderHealthbar = (current: number) => current.toString();
 
 	const returnTitleOrSpacer = (player) => {
-		if (player.profile.title !== null) {
+		if (player.profile.title) {
 			return <Title titleId={player.profile.title} />;
 		}
 		return <div className="spacer" />;


### PR DESCRIPTION
* The returnTitleOrSpacer function was only recognising a lack of title if it was explicitly defined as null - altered this to return a spacer for user players as well as bots if no title was present OR if it is defined as null
* Removed unnecessary renderHealthbar function