### PR TITLE
fix: :bug: Stop default returning to live site when quitting game

### DIFF
--- a/apps/web-game/src/game/sagas/goToMenuAfterGame.ts
+++ b/apps/web-game/src/game/sagas/goToMenuAfterGame.ts
@@ -1,11 +1,12 @@
 import { delay, take } from "@redux-saga/core/effects";
 
 import { GameEvents } from "@creature-chess/gamemode";
+import { config } from "@creature-chess/models";
 
 export const goToMenuAfterGame = function* () {
 	yield take<GameEvents.GameFinishEvent>(GameEvents.gameFinishEvent.toString());
 
 	yield delay(10_000);
 
-	window.location.href = "https://creaturechess.com";
+	window.location.href = config.appUrl;
 };


### PR DESCRIPTION
Prevent returning to live site from development environment when quitting from game to home page.